### PR TITLE
Style the sign in and sign up pages.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,14 +2,17 @@ class SessionsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
 
   def new
+    @user = User.new
   end
 
   def create
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
+
     if @user
       login @user
       redirect_to root_path, notice: "Signed in."
     else
+      @user = User.new(email: params[:user][:email])
       flash.now[:alert] = "Incorrect email or password."
       render :new, status: :unprocessable_entity
     end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -41,10 +41,10 @@
               <a href="/how_to_use" class="ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out">How to use</a>
               <% if user_signed_in? %>
                 <%= link_to "Create Food Pantry", new_user_food_pantry_path(current_user), class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
-                <%= button_to "Sign Out", logout_path, method: :delete, data: { turbo: false }, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
+                <%= button_to "Sign out", logout_path, method: :delete, data: { turbo: false }, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
               <% else %>
-                <%= link_to 'Login', login_path, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
-                <%= link_to "Sign Up", sign_up_path, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
+                <%= link_to "Login", login_path, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
+                <%= link_to "Sign up", sign_up_path, class: "ml-4 px-3 py-2 rounded-md text-sm font-medium leading-5 text-gray-300 hover:text-white hover:bg-gray-700 focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out" %>
               <% end %>
             </div>
           </div>

--- a/app/views/food_pantries/index.html.erb
+++ b/app/views/food_pantries/index.html.erb
@@ -1,4 +1,4 @@
-<%# <div class="bg-gray-100 py-6">
+<%# <div class="py-6">
   <div class="max-w-7xl mx-auto sm:px-6 lg:px-8"> %>
     <div class="flex justify-start space-x-4 pb-6 pl-4 sm:pl-0">
       <%= link_to "Open Now", root_path(filter: "now"), class: "inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="h-full bg-gray-100">
 
 <head>
   <title>Upper Valley Food Pantries</title>
@@ -12,7 +12,7 @@
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 </head>
 
-<body class="bg-gray-100 py-6>
+<body class="h-full py-6">
   <% if notice %>
     <div class="bg-yellow-500 p-4 text-gray-800 text-center">
       <%= notice %>
@@ -24,7 +24,7 @@
     </div>
   <% end %>
   <%= render "header" %>
-  <main class="bg-gray-100 py-6">
+  <main class="py-6">
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
       <%= yield %>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,27 @@
-<%= form_with url: login_path, scope: :user do |form| %>
-  <div>
-    <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">Login</h2>
   </div>
-  <div>
-    <%= form.label :password %>
-    <%= form.password_field :password, required: true %>
+
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+      <%= form_with model: @user, url: login_path, class: "space-y-6" do |form| %>
+        <div>
+          <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= form.text_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          </div>
+        </div>
+        <div>
+          <%= form.label :password, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= form.password_field :password, autocomplete: "current-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          </div>
+        </div>
+        <div>
+          <%= form.submit "Log in", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+        </div>
+      <% end %>
+    </div>
   </div>
-  <%= form.submit "Sign In" %>
-<% end %>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,16 +1,34 @@
-<%= form_with model: @user, url: sign_up_path do |form| %>
-  <%= render partial: "shared/form_errors", locals: { object: form.object } %>
-  <div>
-    <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">Sign up</h2>
   </div>
-  <div>
-    <%= form.label :password %>
-    <%= form.password_field :password, required: true %>
+
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+      <%= form_with model: @user, url: sign_up_path, class: "space-y-6" do |form| %>
+        <%= render partial: "shared/form_errors", locals: { object: form.object } %>
+        <div>
+          <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= form.text_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          </div>
+        </div>
+        <div>
+          <%= form.label :password, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= form.password_field :password, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          </div>
+        </div>
+        <div>
+          <%= form.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= form.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+          </div>
+        </div>
+        <div>
+          <%= form.submit "Sign up", class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+        </div>
+      <% end %>
+    </div>
   </div>
-  <div>
-    <%= form.label :password_confirmation %>
-    <%= form.password_field :password_confirmation, required: true %>
-  </div>
-  <%= form.submit "Sign Up" %>
-<% end %>
+</div>


### PR DESCRIPTION
I also changed the behavior on sign in so when you fail your password,
it keeps the email address the user entered. I opted to switch the form
to specify a model instead of a scope for clarity of binding these
values

<img width="940" alt="Screen Shot 2022-02-05 at 4 14 47 PM" src="https://user-images.githubusercontent.com/21263/152659288-d54e7c0b-3be4-442e-8bb0-1b3dea5caaf9.png">

<img width="833" alt="Screen Shot 2022-02-05 at 4 14 53 PM" src="https://user-images.githubusercontent.com/21263/152659291-5282fd1b-98e1-4e01-bc3e-9482519e5658.png">

